### PR TITLE
Simplify Cloud Function exports

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,7 +7,11 @@ service cloud.firestore {
     }
     match /contracts/{contractId} {
       allow create, update, read: if request.auth != null && request.auth.token.role == "sales";
-      allow read, update: if request.auth == null && resource.data.status == "sent";
+      // Publicly readable when sent, but writes require matching signToken
+      allow read: if request.auth == null && resource.data.status == "sent";
+      allow update: if request.auth == null &&
+                    resource.data.status == "sent" &&
+                    request.resource.data.signToken == resource.data.signToken;
     }
     match /templates/{templateId} {
       allow create, update, read: if request.auth != null && request.auth.token.role == "sales";

--- a/functions/api.js
+++ b/functions/api.js
@@ -93,8 +93,9 @@ app.get('/contracts', requireAuth, requireRole('sales'), async (req, res) => {
 app.post('/contracts/:id/send', requireAuth, requireRole('sales'), async (req, res) => {
   const sent = await sendForSign(req.params.id);
   const base = process.env.PUBLIC_BASE_URL;
-  const signUrl = base ? `${base}/sign/${sent.id}` : `/sign/${sent.id}`;
-  res.json({ ...sent, signUrl });
+  const signToken = sent.signToken;
+  const signUrl = base ? `${base}/sign/${signToken}` : `/sign/${signToken}`;
+  res.json({ ...sent, signToken, signUrl });
 });
 
 app.post('/admin/setAdminRole', requireAuth, requireRole('admin'), async (req, res) => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,16 +1,7 @@
+const functions = require('firebase-functions');
 
 exports.api = require('./api').api;
 exports.web = require('./web').web;
-
-exports.api = functions
-  .runWith({ memory: '1GB', timeoutSeconds: 120 })
-  .https.onRequest(apiApp);
-
-exports.web = functions
-  .runWith({ memory: '1GB', timeoutSeconds: 120 })
-  .https.onRequest(webApp);
-
-const functions = require('firebase-functions');
 const { db, storage } = require('./src/admin');
 const { renderContractHtml, htmlToPdf, simpleContractPdf } = require('./src/services/pdfService');
 
@@ -46,8 +37,13 @@ exports.generatePdf = functions
     const path = `pdf/contracts/${contractId}.pdf`;
     const file = bucket.file(path);
     await file.save(Buffer.from(pdfBytes), {
-      contentType: 'application/pdf',
-      resumable: false
+      resumable: false,
+      metadata: {
+        contentType: 'application/pdf',
+        metadata: {
+          firebaseStorageDownloadTokens: after.signToken
+        }
+      }
     });
 
     await db.collection('contracts').doc(contractId).set({ pdfStoragePath: path }, { merge: true });

--- a/functions/src/services/contracts.store.js
+++ b/functions/src/services/contracts.store.js
@@ -46,9 +46,11 @@ async function updateDraft(id, patch) {
 
 async function sendForSign(id) {
   const ref = db.collection(COL).doc(id);
+  const token = nanoid();
   await ref.set({
     status: 'pending',
-    sentAt: Date.now()
+    sentAt: Date.now(),
+    signToken: token
   }, { merge: true });
   const snap = await ref.get();
   return { id: snap.id, ...snap.data() };
@@ -83,6 +85,25 @@ async function completeById(id, signatureDataUrl) {
   return getById(id);
 }
 
+async function getByToken(token) {
+  const snap = await db.collection(COL).where('signToken', '==', token).limit(1).get();
+  if (snap.empty) return null;
+  const doc = snap.docs[0];
+  return { id: doc.id, ...doc.data() };
+}
+
+async function recordConsentByToken(token, consentFields) {
+  const doc = await getByToken(token);
+  if (!doc) throw new Error('contract not found');
+  return recordConsentById(doc.id, consentFields);
+}
+
+async function completeByToken(token, signatureDataUrl) {
+  const doc = await getByToken(token);
+  if (!doc) throw new Error('contract not found');
+  return completeById(doc.id, signatureDataUrl);
+}
+
 module.exports = {
   createDraft,
   updateDraft,
@@ -90,5 +111,8 @@ module.exports = {
   getById,
   listContracts,
   recordConsentById,
-  completeById
+  completeById,
+  getByToken,
+  recordConsentByToken,
+  completeByToken
 };

--- a/functions/web.js
+++ b/functions/web.js
@@ -10,16 +10,15 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.json({ limit: '10mb' }));
 app.use(cookieParser());
 
-// Render sign page by token: /sign/:token
+// Render sign page by token
 app.get('/sign/:token', async (req, res) => {
   try {
     const token = req.params.token;
     const doc = await getByToken(token);
     if (!doc) return res.status(404).send('Link expired or invalid');
 
-    // choose template based on type
-    const tpl = doc.type === 'individual' ? 'tpl_individual.ejs' :
-                (doc.type === 'flight' ? 'tpl_flight.ejs' : 'tpl_group_old.ejs');
+    const tpl = doc.type === 'individual' ? 'tpl_individual.ejs'
+              : (doc.type === 'flight' ? 'tpl_flight.ejs' : 'tpl_group_old.ejs');
     const templatePath = path.join(__dirname, 'views', tpl);
 
     const model = {
@@ -57,78 +56,7 @@ app.post('/sign/:token/consent', async (req, res) => {
 
 // Complete signature with data URL
 app.post('/sign/:token/complete', async (req, res) => {
-  try {const functions = require('firebase-functions');
-    const express = require('express');
-    const ejs = require('ejs');
-    const cookieParser = require('cookie-parser');
-    const { db } = require('./src/admin');
-    
-    const app = express();
-    app.use(express.urlencoded({ extended: true }));
-    app.use(express.json({ limit: '10mb' }));
-    app.use(cookieParser());
-    
-    // 客戶簽署頁：/sign/:id
-    app.get('/sign/:id', async (req, res) => {
-      try {
-        const id = req.params.id;
-        const snap = await db.collection('contracts').doc(id).get();
-        if (!snap.exists) return res.status(404).send('Contract not found');
-        const doc = { id: snap.id, ...snap.data() };
-    
-        const ts = await db.collection('templates').doc(doc.templateId).get();
-        if (!ts.exists) return res.status(404).send('Template not found');
-        const tpl = ts.data();
-    
-        const model = {
-          travelerName: doc.travelerName,
-          agentName: doc.agentName,
-          createdAt: new Date(doc.createdAt).toISOString().split('T')[0],
-          idNumber: doc.idNumber,
-          phone: doc.phone,
-          address: doc.address,
-          salesName: doc.salesName,
-          signatureImgTag: doc.signatureDataUrl ? `<img src="${doc.signatureDataUrl}" style="max-width:300px">` : '',
-          ...(doc.payload || {})
-        };
-        const html = await ejs.render(tpl.body || '', model, { async: true });
-        res.setHeader('Content-Type', 'text/html; charset=utf-8');
-        res.send(html);
-      } catch (e) {
-        console.error(e);
-        res.status(500).send('Server error');
-      }
-    });
-    
-    app.post('/sign/:id/consent', async (req, res) => {
-      try {
-        const id = req.params.id;
-        const fields = req.body || {};
-        await db.collection('contracts').doc(id).set({ consent: fields }, { merge: true });
-        res.json({ ok: true, id });
-      } catch (e) {
-        res.status(400).json({ ok: false, error: e.message });
-      }
-    });
-    
-    app.post('/sign/:id/complete', async (req, res) => {
-      try {
-        const id = req.params.id;
-        const { signatureDataUrl } = (req.body || {});
-        if (!signatureDataUrl) return res.status(400).json({ ok:false, error:'missing signature' });
-        await db.collection('contracts').doc(id).set({
-          status: 'signed',
-          signedAt: Date.now(),
-          signatureDataUrl
-        }, { merge: true });
-        res.json({ ok: true, id });
-      } catch (e) {
-        res.status(400).json({ ok: false, error: e.message });
-      }
-    });
-    
-    exports.web = functions.runWith({ secrets: ['GOOGLE_SERVICE_ACCOUNT_JSON'] }).https.onRequest(app);
-    
+  try {
     const token = req.params.token;
     const { signatureDataUrl } = req.body;
     if (!signatureDataUrl) return res.status(400).json({ ok:false, error:'missing signature' });
@@ -141,3 +69,4 @@ app.post('/sign/:token/complete', async (req, res) => {
 
 // ← 這行改成宣告 secrets（為了本地以 GOOGLE_SERVICE_ACCOUNT_JSON 直連也能運作）
 exports.web = functions.runWith({ secrets: ['GOOGLE_SERVICE_ACCOUNT_JSON'] }).https.onRequest(app);
+

--- a/hosting/assets/app.js
+++ b/hosting/assets/app.js
@@ -159,7 +159,7 @@ let auth, app;
     const ul = document.getElementById('list');
     ul.innerHTML = '';
     list.forEach(item => {
-      const link = (window.location.origin + `/sign/${item.id}`);
+      const link = item.signUrl || (window.location.origin + `/sign/${item.signToken || item.id}`);
       const li = document.createElement('li');
       li.innerHTML = `${new Date(item.createdAt).toISOString().slice(0,10)} · ${item.type} · ${item.travelerName} · <b>${item.status}</b> · <a href="${link}" target="_blank">簽署連結</a>`;
       ul.appendChild(li);

--- a/storage.rules
+++ b/storage.rules
@@ -4,5 +4,11 @@ service firebase.storage {
     match /contracts/{userId}/{allPaths=**} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
+    match /pdf/contracts/{contractId}.pdf {
+      allow read: if (request.auth != null &&
+                      request.auth.uid == get(/databases/(default)/documents/contracts/$(contractId)).data.ownerUid)
+                    || request.query.token == resource.metadata.firebaseStorageDownloadTokens;
+      allow write: if false;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- generate and store signToken when sending contracts
- add token lookup helpers for contracts and export them
- update web and API layers to use token-based signing endpoints
- tighten Firestore rules to require signToken for unauthenticated updates
- return signToken in send contract response and build signUrl
- consume signUrl/signToken in front-end listing for signing link
- secure contract PDF storage with token-based download access

## Testing
- `npm test` (fails: Could not read package.json)
- `npm --prefix functions test` (fails: Missing script "test")
- `node -e "const { simpleContractPdf } = require('./functions/src/services/pdfService'); simpleContractPdf({id:'c1', travelerName:'T', agentName:'A', status:'signed'}).then(b=>console.log('bytes', b.length)).catch(e=>console.error(e));"` (fails: Cannot find module 'pdf-lib')
- `npm --prefix functions install pdf-lib` (fails: 403 Forbidden)
- `curl -I "https://firebasestorage.googleapis.com/v0/b/dummy-bucket/o/pdf%2Fcontracts%2Fc1.pdf?alt=media&token=abc"` (fails: CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_68aa9a6ff998832b9ecdcaffac54f950